### PR TITLE
Add precommit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+exclude = developer_tools docker docs

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
+ignore = E203, E266, E501, W503, F403, F401
 max-line-length = 120
 exclude = developer_tools docker docs

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E203, E266, E501, W503, F403, F401
+ignore = E126, E203, E266, E501, W503, W504, F403, F401
 max-line-length = 120
-exclude = developer_tools docker docs
+exclude = build developer_tools dist docker docs setup.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+    - id: check-added-large-files
+    - id: check-merge-conflict
+    - id: requirements-txt-fixer
+    - id: end-of-file-fixer
+    - id: name-tests-test
+      args: ['--django']
+-   repo: https://github.com/ambv/black
+    rev: 20.8b1
+    hooks:
+    - id: black
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.0
+    hooks:
+    - id: flake8
+  

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,10 @@ repos:
     rev: v3.4.0
     hooks:
     - id: check-added-large-files
+    - id: check-json
     - id: check-merge-conflict
+    - id: debug-statements
+    - id: pretty-format-json
     - id: requirements-txt-fixer
     - id: end-of-file-fixer
     - id: name-tests-test

--- a/makefile
+++ b/makefile
@@ -54,4 +54,10 @@ run_tests:
 
 # Runs flake8
 run_flake8:
-	flake8 synbols tests --max-line-length=120
+	flake8
+
+# Setup pre-commit hooks
+# XXX: These are useful to run checks on the code before committing
+setup-precommit-hooks:
+	pip install pre-commit
+	pre-commit install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 120
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''


### PR DESCRIPTION
This pull request adds pre-commit hooks to the codebase. Before each commit, these hooks run a bunch of checks on the code to ensure quality. Notably:

* Flake8 is run automatically to avoid the commit -> fix -> commit -> ... loop that often occurs
* Black (a code formatter) automatically fixes formatting issues in the code if there are any. When this occurs, you will get a notification. Simply re-add the files using `git add file.py` and retry committing.

To install the pre-commit hooks on your computer, simply run `make setup-precommit-hooks` locally.