### PR TITLE
add inverse_color attribute

### DIFF
--- a/synbols/drawing.py
+++ b/synbols/drawing.py
@@ -413,6 +413,7 @@ class Image:
             pixel_noise_scale=self.pixel_noise_scale,
             seed=self.seed,
             background=self.background.attribute_dict(),
+            inverse_color=int(self.inverse_color),
         )
         data.update(symbols[0])  # hack to allow flatten access
         data["symbols"] = symbols


### PR DESCRIPTION
Add the inverse color attribute to the Image attribute dict. This is necessary to have information about the background/foreground contrast (black/white or white/black)  in a given generated image.